### PR TITLE
Removed dependency from parent constructor in ReferenceEntity helper

### DIFF
--- a/Helper/Import/ReferenceEntity.php
+++ b/Helper/Import/ReferenceEntity.php
@@ -4,15 +4,8 @@ declare(strict_types=1);
 
 namespace Smile\CustomEntityAkeneo\Helper\Import;
 
-use Akeneo\Connector\Executor\JobExecutor;
-use Akeneo\Connector\Helper\Authenticator;
-use Akeneo\Connector\Helper\Config as ConfigHelper;
 use Akeneo\Connector\Helper\Import\Entities;
-use Magento\Catalog\Model\Product as BaseProductModel;
 use Magento\Eav\Api\Data\AttributeInterface;
-use Magento\Framework\App\DeploymentConfig;
-use Magento\Framework\App\ResourceConnection;
-use Psr\Log\LoggerInterface;
 use Smile\CustomEntityAkeneo\Model\ConfigManager;
 use Smile\CustomEntityAkeneo\Model\Source\Config\Mode;
 use Zend_Db_Statement_Exception;
@@ -20,27 +13,12 @@ use Zend_Db_Statement_Exception;
 /**
  * Reference Entity import helper.
  */
-class ReferenceEntity extends Entities
+class ReferenceEntity
 {
     public function __construct(
-        ResourceConnection $connection,
-        DeploymentConfig $deploymentConfig,
-        BaseProductModel $product,
-        ConfigHelper $configHelper,
-        LoggerInterface $logger,
-        Authenticator $authenticator,
-        JobExecutor $jobExecutor,
+        protected Entities $entitiesHelper,
         protected ConfigManager $configManager
     ) {
-        parent::__construct(
-            $connection,
-            $deploymentConfig,
-            $product,
-            $configHelper,
-            $logger,
-            $authenticator,
-            $jobExecutor
-        );
     }
 
     /**
@@ -50,8 +28,8 @@ class ReferenceEntity extends Entities
      */
     public function getEntitiesToImport(): array
     {
-        $connection = $this->getConnection();
-        $entityTable = $this->getTable('akeneo_connector_entities');
+        $connection = $this->entitiesHelper->getConnection();
+        $entityTable = $this->entitiesHelper->getTable('akeneo_connector_entities');
         $selectExistingEntities = $connection->select()
             ->from(['e' => $entityTable], 'e.code')
             ->where('e.import = ?', 'smile_custom_entity');
@@ -67,15 +45,15 @@ class ReferenceEntity extends Entities
     }
 
     /**
-     * @inheritdoc
+     * Retrieve attribute.
      */
-    public function getAttribute($code, $entityTypeId): bool|array
+    public function getAttribute(string $code, int $entityTypeId): bool|array
     {
-        $connection = $this->connection;
+        $connection = $this->entitiesHelper->getConnection();
 
         $attribute = $connection->fetchRow(
             $connection->select()->from(
-                $this->getTable('eav_attribute'),
+                $this->entitiesHelper->getTable('eav_attribute'),
                 [
                     AttributeInterface::ATTRIBUTE_ID,
                     AttributeInterface::BACKEND_TYPE,
@@ -90,6 +68,7 @@ class ReferenceEntity extends Entities
         if (empty($attribute)) {
             return false;
         }
+
         return $attribute;
     }
 }

--- a/Job/CustomEntityRecord.php
+++ b/Job/CustomEntityRecord.php
@@ -507,7 +507,7 @@ class CustomEntityRecord extends Import
         $connection = $this->entitiesHelper->getConnection();
         $tmpTable = $this->entitiesHelper->getTableName($this->jobExecutor->getCurrentJob()->getCode());
         $tmpAttributeTable = $this->entitiesHelper->getTableName(self::TMP_TABLE_ATTRIBUTE_VALUES);
-        $entityTypeId = $this->configHelper->getEntityTypeId(CustomEntityInterface::ENTITY);
+        $entityTypeId = (int) $this->configHelper->getEntityTypeId(CustomEntityInterface::ENTITY);
         $urlAttribute = $this->referenceEntityHelper->getAttribute(
             CustomEntityInterface::URL_KEY,
             $entityTypeId
@@ -553,7 +553,7 @@ class CustomEntityRecord extends Import
     {
         $connection = $this->entitiesHelper->getConnection();
         $tmpTable = $this->entitiesHelper->getTableName($this->jobExecutor->getCurrentJob()->getCode());
-        $entityTypeId = $this->configHelper->getEntityTypeId(CustomEntityInterface::ENTITY);
+        $entityTypeId = (int) $this->configHelper->getEntityTypeId(CustomEntityInterface::ENTITY);
 
         $isActiveAttribute = $this->referenceEntityHelper->getAttribute(
             CustomEntityInterface::IS_ACTIVE,
@@ -660,7 +660,7 @@ class CustomEntityRecord extends Import
 
         foreach ($attributes as $row) {
             $attribute = $this->referenceEntityHelper->getAttribute(
-                $row['attribute'],
+                (string) $row['attribute'],
                 $entityTypeId
             );
 


### PR DESCRIPTION
While using this module, we noticed that the number of arguments in the Akeneo\Connector\Helper\Import\Entities constructor varies in different versions of the Akeneo connector module. So we decided to remove the parentage in Smile\CustomEntityAkeneo\Helper\Import\ReferenceEntity to not depend on changes in the Akeneo connector module. 

